### PR TITLE
signature-new-message: switch to the explicit store message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test:
 	go test ${packages}
 
 lint:
-	docker run --rm -v ${PWD}:/app -w /app golangci/golangci-lint:v1.45.2 golangci-lint run -v ${packages}
+	docker run --rm -v ${PWD}:/app -w /app golangci/golangci-lint:v1.45.2 golangci-lint run ${packages}
 
 protobuf:
 	docker run --rm       									\

--- a/model/domain/signature.go
+++ b/model/domain/signature.go
@@ -10,6 +10,7 @@ type Signature struct {
 	Signer        []byte
 	Scheme        string
 	MultiHashType uint64
+	Timestamp     uint64
 }
 
 var _ Protobufable = (*Signature)(nil)
@@ -20,6 +21,7 @@ func (s *Signature) ToProto() *pb.Signature {
 		Signer:        s.Signer,
 		Scheme:        s.Scheme,
 		MultiHashType: s.MultiHashType,
+		Timestamp:     s.Timestamp,
 	}
 }
 
@@ -28,6 +30,7 @@ func (s *Signature) ToDomain(pbSignature *pb.Signature) {
 	s.Signer = pbSignature.Signer
 	s.Scheme = pbSignature.Scheme
 	s.MultiHashType = pbSignature.MultiHashType
+	s.Timestamp = pbSignature.Timestamp
 }
 
 func (s *Signature) MarshalProto() ([]byte, error) {

--- a/model/domain/signedpiece.go
+++ b/model/domain/signedpiece.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/cerebellum-network/cere-ddc-sdk-go/core/pkg/cid"
 	"github.com/cerebellum-network/cere-ddc-sdk-go/core/pkg/crypto"
@@ -93,10 +94,10 @@ func (sp *SignedPiece) SigneableCid() (signeable []byte, pieceCid string, err er
 		return nil, "", err
 	}
 
-	timeText := "" // TODO
-	msg := fmt.Sprintf("<Bytes>DDC store %s at %s</Bytes>", pieceCid, timeText)
+	timeText := formatTimestamp(sp.Signature.Timestamp)
+	message := fmt.Sprintf("<Bytes>DDC store %s at %s</Bytes>", pieceCid, timeText)
 
-	return []byte(msg), pieceCid, nil
+	return []byte(message), pieceCid, nil
 }
 
 func (sp *SignedPiece) SetSignature(sig []byte) {
@@ -155,4 +156,9 @@ func maybeDecodeHex(src []byte, bytesLen int) (maybeDecoded []byte) {
 		return decoded
 	}
 	return nil
+}
+
+// Format the time the same way as JavaScript Date.toISOString()
+func formatTimestamp(unixMilli uint64) string {
+	return time.UnixMilli(int64(unixMilli)).UTC().Format("2006-01-02T15:04:05.000Z")
 }

--- a/model/pb/signature.pb.go
+++ b/model/pb/signature.pb.go
@@ -58,8 +58,9 @@ const (
 //
 // #### Legacy signatures before v0.1.4
 //
-// - If `value` is 130 bytes long, and `signer` is 66 bytes long, and they starts with `0x` (UTF-8), decode them from hexadecimal.
-// - Then, the signed message is `${CID}` or `<Bytes>${CID}</Bytes>`.
+// If `timestamp == 0`, assume an older version:
+// - Decode `value` and `signer` from hexadecimal with or without `0x`.
+// - Then the signed message is either `${CID}` or `<Bytes>${CID}</Bytes>`.
 //
 type Signature struct {
 	state         protoimpl.MessageState


### PR DESCRIPTION
Implement the [new signature spec](https://github.com/Cerebellum-Network/ddc-schemas/blob/00ef1359010356a2fc2ec50578f9b83e1025797a/storage/protobuf/signature.proto#L7).

Keep backwards compatibility for easy testnet deployment.