### PR TITLE
url-extension: parse filename extensions

### DIFF
--- a/model/ddcuri/ddcuri.go
+++ b/model/ddcuri/ddcuri.go
@@ -15,9 +15,10 @@ type DdcQuery struct {
 	BucketId    uint32
 	BucketIdSet bool
 
-	Protocol string
-	Cid      string
-	Path     []string
+	Protocol  string
+	Cid       string
+	Path      []string
+	Extension string
 
 	Options string
 }

--- a/model/ddcuri/ddcuri_gen.go
+++ b/model/ddcuri/ddcuri_gen.go
@@ -23,8 +23,8 @@ func (q *DdcQuery) toUri() string {
 	}
 
 	if q.Protocol == IPIECE || q.Protocol == IFILE {
-		parts = append(parts, q.Protocol, q.Cid)
-		// Example output: /ddc/org/my_org/buc/my_bucket/ifile/cid123
+		parts = append(parts, q.Protocol, q.Cid+q.Extension)
+		// Example output: /ddc/org/my_org/buc/my_bucket/ifile/cid123.js
 	} else if q.Protocol == PIECE || q.Protocol == FILE {
 		parts = append(parts, q.Protocol)
 		parts = append(parts, q.Path...)

--- a/model/ddcuri/ddcuri_parser.go
+++ b/model/ddcuri/ddcuri_parser.go
@@ -2,6 +2,7 @@ package ddcuri
 
 import (
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"unicode"
@@ -68,11 +69,12 @@ func consumeProtocol(q *DdcQuery, parts []string) error {
 		field := parts[0]
 		if field == IPIECE || field == IFILE {
 			q.Protocol = field
-			q.Cid = parts[1]
+			q.Cid, q.Extension = splitExtension(parts[1])
 			parts = parts[2:]
 		} else if field == PIECE || field == FILE {
 			q.Protocol = field
 			q.Path = parts[1:]
+			_, q.Extension = splitExtension(parts[len(parts)-1])
 			parts = nil
 		}
 	}
@@ -91,4 +93,13 @@ func consumeEnd(q *DdcQuery, parts []string) error {
 func startsWithDigit(s string) bool {
 	first, _ := utf8.DecodeRuneInString(s)
 	return unicode.IsDigit(first)
+}
+
+func splitExtension(name string) (string, string) {
+	ext := filepath.Ext(name)
+	if ext != "" {
+		// Remove the extension.
+		name = name[:len(name)-len(ext)]
+	}
+	return name, ext
 }

--- a/model/ddcuri/ddcuri_test.go
+++ b/model/ddcuri/ddcuri_test.go
@@ -18,6 +18,17 @@ func TestGoodDdcUri(t *testing.T) {
 		})
 
 	goodDdcUri(t,
+		"/ddc/buc/123/ipiece/cid123.js",
+		"",
+		DdcQuery{
+			Protocol:    "ipiece",
+			BucketId:    123,
+			BucketIdSet: true,
+			Cid:         "cid123",
+			Extension:   ".js",
+		})
+
+	goodDdcUri(t,
 		"  /ddc/buc/123/ipiece/cid123   ",
 		"/ddc/buc/123/ipiece/cid123", // canonical
 		DdcQuery{
@@ -57,6 +68,7 @@ func TestGoodDdcUri(t *testing.T) {
 			Protocol:     "file",
 			Path:         []string{"my_folder", "image.png"},
 			Options:      "option=yes",
+			Extension:    ".png",
 		})
 
 	goodDdcUri(t,
@@ -126,4 +138,18 @@ func TestBadWebUrl(t *testing.T) {
 	if assert.Error(t, err) {
 		assert.Equal(t, err.Error(), "not a DDC URL (htts://cdn-ddc/buc/123)")
 	}
+}
+
+func TestSplitExtension(t *testing.T) {
+
+	check := func(name, expectBase, expectExt string) {
+		base, ext := splitExtension(name)
+		assert.Equal(t, expectBase, base)
+		assert.Equal(t, expectExt, ext)
+	}
+
+	check("", "", "")
+	check("name", "name", "")
+	check("name.js", "name", ".js")
+	check("name.", "name", ".")
 }


### PR DESCRIPTION
Support URLs like this

    /ddc/buc/123/ipiece/cid123.js

and split `cid123` from `.js`

This way we can easily set the content-type in web responses.

[Spec](https://github.com/Cerebellum-Network/docs.cere.network/pull/31/files).