### PR TITLE
Disable contract package CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,14 +56,3 @@ jobs:
           args: --timeout 5m
       - name: 'Run unit tests contentadrstorage module'
         run: go test -v ./contentadrstorage/...
-      #Contract module
-      - name: 'Run linters contract module'
-        uses: golangci/golangci-lint-action@v3
-        with:
-          working-directory: 'contract'
-          version: v1.50
-          args: --timeout 5m
-      - name: 'Run unit tests contract module'
-        run: go test -v ./contract/...
-      - name: 'Run integrational tests with blockchain emulator'
-        run: go test -v ./test/...


### PR DESCRIPTION
There is no intention to develop `contract` package further and it currently prevents other updates to land due to the test failure during CI. See https://github.com/Cerebellum-Network/cere-ddc-sdk-go/actions/runs/6967972536/job/18962158627?pr=70#step:13:228.

The patch removes CI jobs for the `contract` package.
