### PR TITLE
Silence events decoder errors

### DIFF
--- a/blockchain/client.go
+++ b/blockchain/client.go
@@ -159,7 +159,7 @@ func (c *Client) StartEventsListening(
 				events := &pallets.Events{}
 				err = types.EventRecordsRaw(change.StorageData).DecodeEventRecords(meta, events)
 				if err != nil {
-					c.errsListening <- fmt.Errorf("events decoder: %w", err)
+					// c.errsListening <- fmt.Errorf("events decoder: %w", err) // TODO
 					continue
 				}
 


### PR DESCRIPTION
Currently [go-substrate-rpc-client](https://github.com/centrifuge/go-substrate-rpc-client) v4.2.1 is missing a number of events definitions, for instance `Contracts_Called` and `ElectionProviderMultiPhase_ElectionFailed`. The patch silences events decoding errors until the new Polkadot SDK events types are present in the library.