### PR TITLE
Update events types to blockchain `v5.0.0`

### DIFF
--- a/blockchain/pallets/ddccustomers.go
+++ b/blockchain/pallets/ddccustomers.go
@@ -29,28 +29,29 @@ type UnlockChunk struct {
 // Events
 type (
 	EventDdcCustomersDeposited struct {
-		Phase  types.Phase
-		Owner  types.AccountID
-		Amount types.U128
-		Topics []types.Hash
+		Phase   types.Phase
+		OwnerId types.AccountID
+		Amount  types.U128
+		Topics  []types.Hash
 	}
 	EventDdcCustomersInitialDepositUnlock struct {
-		Phase  types.Phase
-		Owner  types.AccountID
-		Amount types.U128
-		Topics []types.Hash
+		Phase   types.Phase
+		OwnerId types.AccountID
+		Amount  types.U128
+		Topics  []types.Hash
 	}
 	EventDdcCustomersWithdrawn struct {
-		Phase  types.Phase
-		Owner  types.AccountID
-		Amount types.U128
-		Topics []types.Hash
+		Phase   types.Phase
+		OwnerId types.AccountID
+		Amount  types.U128
+		Topics  []types.Hash
 	}
 	EventDdcCustomersCharged struct {
-		Phase  types.Phase
-		Owner  types.AccountID
-		Amount types.U128
-		Topics []types.Hash
+		Phase            types.Phase
+		OwnerId          types.AccountID
+		Charged          types.U128
+		ExpectedToCharge types.U128
+		Topics           []types.Hash
 	}
 	EventDdcCustomersBucketCreated struct {
 		Phase    types.Phase

--- a/blockchain/pallets/ddcpayouts.go
+++ b/blockchain/pallets/ddcpayouts.go
@@ -95,6 +95,7 @@ type (
 	EventDdcPayoutsBillingReportInitialized struct {
 		Phase     types.Phase
 		ClusterId ClusterId
+		Era       DdcEra
 		Topics    []types.Hash
 	}
 
@@ -116,13 +117,14 @@ type (
 	}
 
 	EventDdcPayoutsChargeFailed struct {
-		Phase      types.Phase
-		ClusterId  ClusterId
-		Era        DdcEra
-		BatchIndex BatchIndex
-		CustomerId types.AccountID
-		Amount     types.U128
-		Topics     []types.Hash
+		Phase            types.Phase
+		ClusterId        ClusterId
+		Era              DdcEra
+		BatchIndex       BatchIndex
+		CustomerId       types.AccountID
+		Charged          types.U128
+		ExpectedToCharge types.U128
+		Topics           []types.Hash
 	}
 
 	EventDdcPayoutsIndebted struct {
@@ -173,12 +175,34 @@ type (
 	}
 
 	EventDdcPayoutsRewarded struct {
-		Phase          types.Phase
-		ClusterId      ClusterId
-		Era            DdcEra
-		NodeProviderId types.AccountID
-		Amount         types.U128
-		Topics         []types.Hash
+		Phase            types.Phase
+		ClusterId        ClusterId
+		Era              DdcEra
+		BatchIndex       BatchIndex
+		NodeProviderId   types.AccountID
+		Rewarded         types.U128
+		ExpectedToReward types.U128
+		Topics           []types.Hash
+	}
+
+	EventDdcPayoutsNotDistributedReward struct {
+		Phase             types.Phase
+		ClusterId         ClusterId
+		Era               DdcEra
+		BatchIndex        BatchIndex
+		NodeProviderId    types.AccountID
+		ExpectedReward    types.U128
+		DistributedReward types.U128
+		Topics            []types.Hash
+	}
+
+	EventDdcPayoutsNotDistributedOverallReward struct {
+		Phase                  types.Phase
+		ClusterId              ClusterId
+		Era                    DdcEra
+		ExpectedReward         types.U128
+		TotalDistributedReward types.U128
+		Topics                 []types.Hash
 	}
 
 	EventDdcPayoutsRewardingFinished struct {
@@ -199,6 +223,17 @@ type (
 		Phase            types.Phase
 		AuthorisedCaller types.AccountID
 		Topics           []types.Hash
+	}
+
+	EventDdcPayoutsChargeError struct {
+		Phase      types.Phase
+		ClusterId  ClusterId
+		Era        DdcEra
+		BatchIndex BatchIndex
+		CustomerId types.AccountID
+		Amount     types.U128
+		Error      types.DispatchError
+		Topics     []types.Hash
 	}
 )
 

--- a/blockchain/pallets/ddcpayouts.go
+++ b/blockchain/pallets/ddcpayouts.go
@@ -172,12 +172,6 @@ type (
 		Topics    []types.Hash
 	}
 
-	EventDdcPayouts struct {
-		Phase     types.Phase
-		ClusterId ClusterId
-		Topics    []types.Hash
-	}
-
 	EventDdcPayoutsRewarded struct {
 		Phase          types.Phase
 		ClusterId      ClusterId

--- a/blockchain/pallets/events.go
+++ b/blockchain/pallets/events.go
@@ -43,9 +43,12 @@ type Events struct {
 	DdcPayouts_ValidatorFeesCollected      []EventDdcPayoutsValidatorFeesCollected      //nolint:stylecheck,golint
 	DdcPayouts_RewardingStarted            []EventDdcPayoutsRewardingStarted            //nolint:stylecheck,golint
 	DdcPayouts_Rewarded                    []EventDdcPayoutsRewarded                    //nolint:stylecheck,golint
+	DdcPayouts_NotDistributedReward        []EventDdcPayoutsNotDistributedReward        //nolint:stylecheck,golint
+	DdcPayouts_NotDistributedOverallReward []EventDdcPayoutsNotDistributedOverallReward //nolint:stylecheck,golint
 	DdcPayouts_RewardingFinished           []EventDdcPayoutsRewardingFinished           //nolint:stylecheck,golint
 	DdcPayouts_BillingReportFinalized      []EventDdcPayoutsBillingReportFinalized      //nolint:stylecheck,golint
 	DdcPayouts_AuthorisedCaller            []EventDdcPayoutsAuthorisedCaller            //nolint:stylecheck,golint
+	DdcPayouts_ChargeError                 []EventDdcPayoutsChargeError                 //nolint:stylecheck,golint
 
 	DdcStaking_Bonded    []EventDdcStakingBonded    //nolint:stylecheck,golint
 	DdcStaking_Chilled   []EventDdcStakingChilled   //nolint:stylecheck,golint


### PR DESCRIPTION
Cerebellum blockchain node `v5.0.0` has changes in `pallet-ddc-customers` and `pallet-ddc-payouts` events types as well as new events. We reflect these changes in the patch.