### PR TITLE
Update metadata for each block

### DIFF
--- a/blockchain/client.go
+++ b/blockchain/client.go
@@ -158,6 +158,12 @@ func (c *Client) StartEventsListening(
 				continue
 			}
 
+			meta, err := c.RPC.State.GetMetadata(set.Block)
+			if err != nil {
+				c.errsListening <- fmt.Errorf("get metadata: %w", err)
+				return
+			}
+
 			for _, change := range set.Changes {
 				if !codec.Eq(change.StorageKey, key) || !change.HasStorageData {
 					continue


### PR DESCRIPTION
Update metadata for each block in order to avoid events decoding errors after a runtime upgrades.