### PR TITLE
Continue events listening after blockchain RPC unavailability

### DIFF
--- a/blockchain/client.go
+++ b/blockchain/client.go
@@ -197,7 +197,9 @@ func (c *Client) StartEventsListening(
 	}(headersC, eventsC)
 
 	// Invoke listeners.
+	wg.Add(1)
 	go func(eventsC <-chan blockEvents) {
+		defer wg.Done()
 		for blockEvents := range eventsC {
 			for callback := range c.eventsListeners {
 				(*callback)(blockEvents.Events, blockEvents.Number, blockEvents.Hash)

--- a/blockchain/client.go
+++ b/blockchain/client.go
@@ -123,12 +123,12 @@ func (c *Client) StartEventsListening(
 		defer wg.Done()
 		defer close(headersC)
 
-		for set := range hist {
-			headersC <- set
+		for header := range hist {
+			headersC <- header
 		}
 
-		for set := range live {
-			headersC <- set
+		for header := range live {
+			headersC <- header
 		}
 	}(histHeadersC, liveHeadersC, headersC)
 

--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -2,7 +2,10 @@ module github.com/cerebellum-network/cere-ddc-sdk-go/blockchain
 
 go 1.18
 
-require github.com/centrifuge/go-substrate-rpc-client/v4 v4.2.1
+require (
+	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/centrifuge/go-substrate-rpc-client/v4 v4.2.1
+)
 
 require (
 	github.com/ChainSafe/go-schnorrkel v1.1.0 // indirect

--- a/blockchain/go.sum
+++ b/blockchain/go.sum
@@ -6,6 +6,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/btcsuite/btcd/btcec/v2 v2.2.0 h1:fzn1qaOt32TuLjFlkzYSsBC35Q3KUjT1SwPxiMSCF5k=
 github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce h1:YtWJF7RHm2pYCvA5t0RPmAaLUhREsKuKd+SLhxFbFeQ=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
It will retry events retrieval requests with up to 10 minutes delay between attempts.