### PR TITLE
Update `cere-substrate-rpc-client-go` to `v4.0.0+f2363a3`

### DIFF
--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -33,4 +33,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/centrifuge/go-substrate-rpc-client/v4 v4.2.1 => github.com/Cerebellum-Network/cere-substrate-rpc-client-go/v4 v4.0.0-20240528103741-c0b9d7116ed4
+replace github.com/centrifuge/go-substrate-rpc-client/v4 v4.2.1 => github.com/Cerebellum-Network/cere-substrate-rpc-client-go/v4 f2363a34c4d5b61327c884a2fc1fe8bd797011e0

--- a/blockchain/go.mod
+++ b/blockchain/go.mod
@@ -33,4 +33,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/centrifuge/go-substrate-rpc-client/v4 v4.2.1 => github.com/Cerebellum-Network/cere-substrate-rpc-client-go/v4 f2363a34c4d5b61327c884a2fc1fe8bd797011e0
+replace github.com/centrifuge/go-substrate-rpc-client/v4 v4.2.1 => github.com/Cerebellum-Network/cere-substrate-rpc-client-go/v4 v4.0.0-20240710072231-f2363a34c4d5

--- a/blockchain/go.sum
+++ b/blockchain/go.sum
@@ -1,5 +1,5 @@
-github.com/Cerebellum-Network/cere-substrate-rpc-client-go/v4 v4.0.0-20240528103741-c0b9d7116ed4 h1:JN3HK887OsgrpAuinStxbsVHpdiVFgAFdizDnRjE1qU=
-github.com/Cerebellum-Network/cere-substrate-rpc-client-go/v4 v4.0.0-20240528103741-c0b9d7116ed4/go.mod h1:k61SBXqYmnZO4frAJyH3iuqjolYrYsq79r8EstmklDY=
+github.com/Cerebellum-Network/cere-substrate-rpc-client-go/v4 v4.0.0-20240710072231-f2363a34c4d5 h1:17q2j5vzhjMSwWHEPtc8/d9lGuoDStimRBwIS8DBHZ8=
+github.com/Cerebellum-Network/cere-substrate-rpc-client-go/v4 v4.0.0-20240710072231-f2363a34c4d5/go.mod h1:k61SBXqYmnZO4frAJyH3iuqjolYrYsq79r8EstmklDY=
 github.com/ChainSafe/go-schnorrkel v1.1.0 h1:rZ6EU+CZFCjB4sHUE1jIu8VDoB/wRKZxoe1tkcO71Wk=
 github.com/ChainSafe/go-schnorrkel v1.1.0/go.mod h1:ABkENxiP+cvjFiByMIZ9LYbRoNNLeBLiakC1XeTFxfE=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=

--- a/go.work.sum
+++ b/go.work.sum
@@ -144,6 +144,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v0.6.0 h1:XMEdVDFxgul
 github.com/AzureAD/microsoft-authentication-library-for-go v0.6.0/go.mod h1:BDJ5qMFKx9DugEg3+uQSDCdbYPr5s9vBTrL9P8TpqOU=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802 h1:1BDTz0u9nC3//pOCMdNH+CiXJVYJh5UQNCOBG7jbELc=
+github.com/Cerebellum-Network/cere-substrate-rpc-client-go/v4 v4.0.0-20240710072231-f2363a34c4d5 h1:17q2j5vzhjMSwWHEPtc8/d9lGuoDStimRBwIS8DBHZ8=
+github.com/Cerebellum-Network/cere-substrate-rpc-client-go/v4 v4.0.0-20240710072231-f2363a34c4d5/go.mod h1:k61SBXqYmnZO4frAJyH3iuqjolYrYsq79r8EstmklDY=
 github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
 github.com/Microsoft/hcsshim v0.9.7 h1:mKNHW/Xvv1aFH87Jb6ERDzXTJTLPlmzfZ28VBFD/bfg=
 github.com/Microsoft/hcsshim v0.9.7/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=


### PR DESCRIPTION
The updated version contains a fix (https://github.com/Cerebellum-Network/cere-substrate-rpc-client-go/commit/f2363a34c4d5b61327c884a2fc1fe8bd797011e0) for the RPC client events retriever. Current version fails on a block without events, for instance on a `0` block of a blockchain. It makes [Cerebellum-Network/ddc-storage-node](https://github.com/Cerebellum-Network/ddc-storage-node) events listening fail in if the node connects to the RPC at `0` block. It may also fail on non-genesis blocks in a blockchain without `pallet-timestamp` which typically adds at least one event (block timestamp set extrinsic success) to the block.
