### PR TITLE
Blockchain runtime v54112 support

### DIFF
--- a/blockchain/pallets/ddcclusters.go
+++ b/blockchain/pallets/ddcclusters.go
@@ -9,11 +9,12 @@ import (
 )
 
 type Cluster struct {
-	ClusterId ClusterId
-	ManagerId types.AccountID
-	ReserveId types.AccountID
-	Props     ClusterProps
-	Status    ClusterStatus
+	ClusterId          ClusterId
+	ManagerId          types.AccountID
+	ReserveId          types.AccountID
+	Props              ClusterProps
+	Status             ClusterStatus
+	LastValidatedEraId DdcEra
 }
 
 type ClusterProps struct {

--- a/blockchain/pallets/ddccustomers.go
+++ b/blockchain/pallets/ddccustomers.go
@@ -14,11 +14,12 @@ type AccountsLedger struct {
 }
 
 type Bucket struct {
-	BucketId  BucketId
-	OwnerId   types.AccountID
-	ClusterId ClusterId
-	IsPublic  types.Bool
-	IsRemoved types.Bool
+	BucketId            BucketId
+	OwnerId             types.AccountID
+	ClusterId           ClusterId
+	IsPublic            types.Bool
+	IsRemoved           types.Bool
+	TotalCustomersUsage types.Option[CustomerUsage]
 }
 
 type UnlockChunk struct {

--- a/blockchain/pallets/primitives.go
+++ b/blockchain/pallets/primitives.go
@@ -79,6 +79,7 @@ type StorageNodeMode struct {
 	IsFull    bool
 	IsStorage bool
 	IsCache   bool
+	IsDac     bool
 }
 
 func (m *StorageNodeMode) Decode(decoder scale.Decoder) error {
@@ -94,6 +95,8 @@ func (m *StorageNodeMode) Decode(decoder scale.Decoder) error {
 		m.IsStorage = true
 	} else if b == 3 {
 		m.IsCache = true
+	} else if b == 4 {
+		m.IsDac = true
 	} else {
 		return ErrUnknownVariant
 	}
@@ -109,6 +112,8 @@ func (m StorageNodeMode) Encode(encoder scale.Encoder) error {
 		err = encoder.PushByte(2)
 	} else if m.IsCache {
 		err = encoder.PushByte(3)
+	} else if m.IsDac {
+		err = encoder.PushByte(4)
 	} else {
 		return ErrUnknownVariant
 	}

--- a/blockchain/pallets/primitives.go
+++ b/blockchain/pallets/primitives.go
@@ -169,3 +169,10 @@ func (m ClusterStatus) Encode(encoder scale.Encoder) error {
 
 	return nil
 }
+
+type CustomerUsage struct {
+	TransferredBytes types.U64
+	StoredBytes      types.I64
+	NumberOfPuts     types.U64
+	NumberOfGets     types.U64
+}


### PR DESCRIPTION
Existing SDK types changed according to https://github.com/Cerebellum-Network/blockchain-node/compare/743b403...32dbf72.