### PR TITLE
Blockchain runtime v54113 support

### DIFF
--- a/blockchain/pallets/ddcnodes.go
+++ b/blockchain/pallets/ddcnodes.go
@@ -16,6 +16,7 @@ type StorageNode struct {
 	ProviderId types.AccountID
 	ClusterId  types.Option[ClusterId]
 	Props      StorageNodeProps
+	TotalUsage types.Option[NodeUsage]
 }
 
 // TODO: `Host` is not `[MaxHostLen]types.U8` because the original `BoundedVec<_, MaxHostLen>`

--- a/blockchain/pallets/primitives.go
+++ b/blockchain/pallets/primitives.go
@@ -181,3 +181,10 @@ type CustomerUsage struct {
 	NumberOfPuts     types.U64
 	NumberOfGets     types.U64
 }
+
+type NodeUsage struct {
+	TransferredBytes types.U64
+	StoredBytes      types.I64
+	NumberOfPuts     types.U64
+	NumberOfGets     types.U64
+}


### PR DESCRIPTION
https://github.com/Cerebellum-Network/blockchain-node/pull/412 adds `ddc_nodes::StorageNode.total_usage` field.